### PR TITLE
feat: added internal assessment and api statuses items to navbar

### DIFF
--- a/modules/super-admin/components/navigations/SuperAdminNavbar.tsx
+++ b/modules/super-admin/components/navigations/SuperAdminNavbar.tsx
@@ -1,7 +1,16 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import logo from '../../../../public/assets/404/logo-zuri-auth.svg';
-import { Book, Chart, I24Support, I3Dcube, Notification, Personalcard, SearchNormal1 } from 'iconsax-react';
+import {
+  Book,
+  Chart,
+  I24Support,
+  I3Dcube,
+  Notification,
+  Personalcard,
+  SearchNormal1,
+  SecuritySafe,
+} from 'iconsax-react';
 import { Input } from '@ui/Input';
 import { useRouter } from 'next/router';
 import Sidebar from './SuperAdminSidebar';
@@ -27,11 +36,16 @@ export const menu = [
     to: '/super-admin/feedback-and-customer-support',
     icon: <I24Support size="20" />,
   },
-  // {
-  //   title: 'Internal Assessment',
-  //   to: '/assessment',
-  //   icon: <Book size="20" />
-  // }
+  {
+    title: 'Internal Assessment',
+    to: '/super-admin/assessment',
+    icon: <Book size="20" />,
+  },
+  {
+    title: 'API Statuses',
+    to: '/super-admin/api-statuses',
+    icon: <SecuritySafe size="20" />,
+  },
 ];
 
 const SuperAdminNavbar = () => {
@@ -46,6 +60,10 @@ const SuperAdminNavbar = () => {
         return 'Vendor Management';
       case route.includes('/super-admin/feedback-and-customer-support'):
         return 'Feedback & Customer Support';
+      case route.includes('/super-admin/assessment'):
+        return 'Internal Assessment';
+      case route.includes('/super-admin/api-statuses'):
+        return 'API Statuses';
       default:
         return '';
     }


### PR DESCRIPTION
# Linear Ticket [SUP-30](https://linear.app/zuri-project/issue/SUP-30/add-a-route-on-the-main-and-side-nav-to-the-internal-assessment-page)

# Changes proposed
Added internal assessment and API statuses modules to the Super Admin's navbar and sidebar.

# Check List (Check all the applicable boxes)

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the **main branch** (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

# Screenshots/ Videos
<img width="1440" alt="Screenshot 2023-10-12 at 12 50 21" src="https://github.com/hngx-org/zuriportfolio-frontend/assets/77916165/17dafdc9-dd99-4558-91a2-e55d8263f0b6">
<img width="955" alt="Screenshot 2023-10-12 at 12 50 35" src="https://github.com/hngx-org/zuriportfolio-frontend/assets/77916165/a4a1acff-4544-463c-896d-470acfafa8aa">

