### PR TITLE
Za022/feat/2 fa

### DIFF
--- a/http/index.ts
+++ b/http/index.ts
@@ -95,11 +95,9 @@ export const verfiy2FA = async (props: { email: string; token: string }) => {
 
   try {
     const res = await $http.post('/api/auth/2fa/verify-code', props);
-    console.log(res);
+    return res;
   } catch (e: any) {
-    console.log(e);
-    if (e?.response?.data && e?.response?.data?.message) {
-      console.log(e?.response.data.message);
-    }
+    console.log(e)
+  return e;
   }
 };

--- a/http/index.ts
+++ b/http/index.ts
@@ -63,3 +63,21 @@ export const makePayment = async (selectedPaymentMethod: string) => {
     throw new Error('Please select a payment method before making the payment.');
   }
 };
+
+export const verfiy2FA = async (props: { email: string; token: string }) => {
+  const $http = axios.create({
+    baseURL: "https://auth.akuya.tech",
+    timeout: 30000,
+    headers: {
+      'Content-Type': 'application/json; charset=UTF-8',
+    },
+  });
+
+  try {
+    const res = await $http.post('/api/auth/2fa/verify-code', props);
+    return res;
+  } catch (e: any) {
+    console.log(e)
+  return e;
+  }
+};

--- a/http/index.ts
+++ b/http/index.ts
@@ -64,26 +64,6 @@ export const makePayment = async (selectedPaymentMethod: string) => {
   }
 };
 
-export const guestSignup = async (props: { email: string; firstName: string; lastName: string; password: string }) => {
-  const $http = axios.create({
-    baseURL: "https://auth.akuya.tech",
-    timeout: 30000,
-    headers: {
-      'Content-Type': 'application/json; charset=UTF-8',
-    },
-  });
-
-  try {
-    const res = await $http.post('/api/auth/signup', props);
-    console.log(res?.data);
-    return res?.data;
-  } catch (e: any) {
-    console.log(e);
-    return e.response.data ?? { message: e.message };
-  }
-};
-
-
 export const verfiy2FA = async (props: { email: string; token: string }) => {
   const $http = axios.create({
     baseURL: "https://auth.akuya.tech",

--- a/http/index.ts
+++ b/http/index.ts
@@ -66,7 +66,7 @@ export const makePayment = async (selectedPaymentMethod: string) => {
 
 export const guestSignup = async (props: { email: string; firstName: string; lastName: string; password: string }) => {
   const $http = axios.create({
-    baseURL: AUTH_HTTP_URL,
+    baseURL: "https://auth.akuya.tech",
     timeout: 30000,
     headers: {
       'Content-Type': 'application/json; charset=UTF-8',
@@ -80,5 +80,26 @@ export const guestSignup = async (props: { email: string; firstName: string; las
   } catch (e: any) {
     console.log(e);
     return e.response.data ?? { message: e.message };
+  }
+};
+
+
+export const verfiy2FA = async (props: { email: string; token: string }) => {
+  const $http = axios.create({
+    baseURL: "https://auth.akuya.tech",
+    timeout: 30000,
+    headers: {
+      'Content-Type': 'application/json; charset=UTF-8',
+    },
+  });
+
+  try {
+    const res = await $http.post('/api/auth/2fa/verify-code', props);
+    console.log(res);
+  } catch (e: any) {
+    console.log(e);
+    if (e?.response?.data && e?.response?.data?.message) {
+      console.log(e?.response.data.message);
+    }
   }
 };

--- a/http/index.ts
+++ b/http/index.ts
@@ -63,21 +63,3 @@ export const makePayment = async (selectedPaymentMethod: string) => {
     throw new Error('Please select a payment method before making the payment.');
   }
 };
-
-export const verfiy2FA = async (props: { email: string; token: string }) => {
-  const $http = axios.create({
-    baseURL: "https://auth.akuya.tech",
-    timeout: 30000,
-    headers: {
-      'Content-Type': 'application/json; charset=UTF-8',
-    },
-  });
-
-  try {
-    const res = await $http.post('/api/auth/2fa/verify-code', props);
-    return res;
-  } catch (e: any) {
-    console.log(e)
-  return e;
-  }
-};

--- a/modules/auth/Code2FA.tsx
+++ b/modules/auth/Code2FA.tsx
@@ -4,15 +4,16 @@ import Button from '../../components/ui/Button';
 import Logic2FA from '../../modules/auth/Logic2FA';
 
 function Code2FAUI() {
-  const { digits, inputRefs, handlePaste, handleKeyDown, handleDigitChange, handleSubmit } = Logic2FA();
+  const { digits, inputRefs, handlePaste, handleKeyDown, handleDigitChange, handleSubmit, loading } = Logic2FA();
 
   return (
     <>
       <h2 className="text-2xl md:text-4xl text-center lg:pt-0 font-bold lg:text-left max-w-[20ch] lg:self-start">
         A code has been sent to your mail
       </h2>
-      <form className="flex flex-col gap-10 items-center w-full">
-        <p className="text-base lg:self-start text-gray-700 mb-[-1.8rem]">Enter 6 digit code</p>
+      <form className="flex flex-col gap-10 items-center w-full" onSubmit={handleSubmit}>
+        <p className="text-base lg:self-start text-gray-700 mb-[-1.8rem]">Enter 6 digit code
+         </p>
         <div className="grid grid-cols-6 gap-3 justify-center lg:self-start relative">
           {digits.map((digit, index) => (
             <input
@@ -26,16 +27,16 @@ function Code2FAUI() {
               onChange={(e) => handleDigitChange(index, e)}
               onKeyDown={(e) => handleKeyDown(e, index)}
               onPaste={(e) => handlePaste(e, index)}
-              onSubmit={handleSubmit}
               ref={inputRefs[index]}
               aria-label={`Digit ${index + 1}`}
-              className="w-9 h-9 md:w-14 md:h-14 text-center border border-gray-300 rounded border-opacity-70 focus:outline-green-600"
+              className="w-9 h-9 md:w-[43px] md:h-14 text-center border border-gray-300 rounded border-opacity-70 focus:outline-green-600"
             />
           ))}
           <span className="text-gray-500 absolute top-2 md:top-5 left-1/2 ml-[-0.7%]">-</span>
         </div>
 
         <Button
+          isLoading={loading}
           className={`w-full md:w-10/12 lg:w-11/12 m-auto md:m-0 h-14
           lg:self-start rounded-lg text-base
           ${
@@ -50,7 +51,7 @@ function Code2FAUI() {
         aria-label="Resend code"
         className="bg-tranparent text-gray-700 hover-bg-transparent
         mx-auto p-0 justtify-self-center self-center font-base text-center
-        active:bg-transparent focus:bg-transparent"
+        active:bg-transparent focus:bg-transparent hover:bg-transparent"
       >
         Did not receive code? <span className="text-green-600 ml-[-4px]">Resend</span>
       </Button>

--- a/modules/auth/Logic2FA.tsx
+++ b/modules/auth/Logic2FA.tsx
@@ -1,34 +1,37 @@
-import React, { ChangeEvent, useState, useEffect, useRef } from 'react';
-import jwtDecode from 'jwt-decode';
+import React, { ChangeEvent, useState, useRef, useContext } from 'react';
 import useAuthMutation from '../../hooks/Auth/useAuthMutation';
-import { verfiy2FA } from '../../http/auth';
-import isAuthenticated from '../../helpers/isAuthenticated';
+import { useAuth } from '../../context/AuthContext';
+import { verfiy2FA  } from '../../http';
+import Router, { useRouter } from 'next/router';
+import { notify } from '@ui/Toast';
 
 type InputRef = React.RefObject<HTMLInputElement>; // Define a type for the input refs
 
 function Code2FALogic() {
+  const router = useRouter();
   const [digits, setDigits] = useState<string[]>(['', '', '', '', '', '']);
+  const [error, setError] = useState<string>("");
+  const [loading, setLoading] = useState<boolean>(false);
   const inputRefs: InputRef[] = [useRef(null), useRef(null), useRef(null), useRef(null), useRef(null), useRef(null)];
-  interface DecodedToken {
-    email: string;
-  }
-  useEffect(() => {
-    const token = localStorage.getItem('authToken');
-
-    if (token !== null) {
-      const decodedToken = jwtDecode(token) as DecodedToken;
-
-      if (isAuthenticated(token)) {
-        const userEmail = decodedToken.email;
-
-        console.log(`User's email: ${userEmail}`);
-      } else {
-        console.log('User is not authenticated.');
-      }
-    } else {
-      console.log('Token is null.');
+  const auth = useAuth();
+  const email = auth.email;
+  const mutateFn = useAuthMutation(verfiy2FA,  {
+    onSuccess: (data) => {
+     if(data.response.data.status && data.response.data.status == "Error") {
+      notify({
+          message: data.response.data?.message || "Error! Invalid code",
+          type: 'error',
+        });
+     } else {
+      notify({
+          message: '2FA verified',
+          type: 'success',
+        });
+      router.push("/");
+     }
     }
-  }, []);
+  });
+
 
   function handlePaste(e: React.ClipboardEvent<HTMLInputElement>, index: number) {
     e.preventDefault();
@@ -94,24 +97,23 @@ function Code2FALogic() {
     }
   };
 
-  const loginFn = useAuthMutation(verfiy2FA);
-  const handleSubmit = (event: ChangeEvent<HTMLInputElement>): void => {
-    event.preventDefault();
-    const Token = localStorage.getItem('authToken');
-    if (Token !== null) {
-      const decodedToken = jwtDecode(Token) as DecodedToken; // Assuming you've defined DecodedToken
-      const email = decodedToken.email;
-      const token = digits.toString();
-      loginFn.mutate({ email, token });
-    } else {
-      console.log('Token is null. Unable to proceed.');
-    }
-  };
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
+  event.preventDefault();
+  const token = digits.toString();
+  setLoading(true);
+   setTimeout(() => {
+    mutateFn.mutate({ email: email as string, token: token as string });
+    setLoading(false);
+  }, 700);
+}
 
   const handleResend = (event: ChangeEvent<HTMLInputElement>): void => {
     event.preventDefault();
   };
-  return { digits, inputRefs, handlePaste, handleKeyDown, handleDigitChange, handleSubmit, handleResend };
+
+
+  return { digits, inputRefs, handlePaste, handleKeyDown, handleDigitChange, handleSubmit, handleResend, loading};
 }
 
 export default Code2FALogic;
+

--- a/pages/auth/2fa.tsx
+++ b/pages/auth/2fa.tsx
@@ -3,6 +3,7 @@ import Code2FA from '../../modules/auth/Code2FA';
 import UI2FA from '../../modules/auth/UI2FA';
 import React from 'react';
 import AuthLayout from '@modules/auth/component/AuthLayout';
+import withAuth from '../../helpers/withAuth';
 
 function _2FA() {
   return (
@@ -16,4 +17,4 @@ function _2FA() {
     </AuthLayout>
   );
 }
-export default _2FA;
+export default withAuth(_2FA);


### PR DESCRIPTION
# Linear Ticket
ZA002 

# Changes proposed

> Added API integration, notify toast to show the user error and success massages on 2fa page and added withAuth to the page to protect it from unauthorized users. 

# Note
my local copy doesn't have the full signup and login flow and therefore I was testing with a hard-coded email (hence user couldn't be found). Email is not set based on what's in auth and page can't be accessed without the user being logged in.

# Screenshots/ Videos


![Error](https://i.ibb.co/1rvfZ5q/Screenshot-2023-10-13-at-7-41-45-PM-2.png)

