### PR TITLE
Removed extra props in 2FA enable/disable functions

### DIFF
--- a/http/auth.ts
+++ b/http/auth.ts
@@ -27,7 +27,7 @@ export const resend2FACode = async (props: { email: string }) => {
   }
 };
 
-export const enabled2FA = async (props: {email: string, token: string}) => {
+export const enabled2FA = async (props: {token: string}) => {
   try {
     const res = await $http.post('/2fa/enable', props);
     return res?.data;
@@ -36,7 +36,7 @@ export const enabled2FA = async (props: {email: string, token: string}) => {
   }
 }
 
-export const disable2FA = async (props: {email: string, token: string}) => {
+export const disable2FA = async (props: {token: string}) => {
   try {
     const res = await $http.post('/2fa/disable', props);
     return res?.data;


### PR DESCRIPTION


# Linear Ticket

AZ022

# Changes proposed

> I added by mistake an extra props for sending a post request to enable and disable 2FA. Only token is send, no need to send the email.


# Screenshots/ Videos
![Screenshot 2023-10-16 at 9 45 40 PM (2)](https://github.com/hngx-org/zuriportfolio-frontend/assets/74996096/71f9306b-c0db-41c5-8ee7-3eaddd037bb2)

