### PR TITLE
Fixed a bug that allows users with 2fa enabled to login without providing the 6-digits code

### DIFF
--- a/modules/auth/Logic2FA.tsx
+++ b/modules/auth/Logic2FA.tsx
@@ -19,6 +19,8 @@ function Code2FALogic() {
       if (res.status === 200) {
         handleAuth(res.data);
         localStorage.setItem('zpt', res?.data?.token);
+        localStorage.removeItem('email');
+        localStorage.removeItem('2fa');
 
         // redirecting the user  to admin dashbord if they are an admin
         if (res.data.user.roleId === ADMIN_ID) {
@@ -43,7 +45,7 @@ function Code2FALogic() {
   });
 
   useEffect(() => {
-    let token = localStorage.getItem('zpt');
+    let token = localStorage.getItem('2fa');
     if (typeof window !== undefined) {
       setToken(token as string);
     }
@@ -54,7 +56,7 @@ function Code2FALogic() {
       console.log(res?.response);
       if (res?.response?.status === 200) {
         console.log(res?.response?.status);
-        localStorage.setItem('zpt', res?.response?.token);
+        localStorage.setItem('2fa', res?.response?.token);
         setToken(res?.response?.token);
         notify({
           message: 'Two Factor Authentication Code Re-sent',

--- a/modules/auth/component/Login/LoginForm.tsx
+++ b/modules/auth/component/Login/LoginForm.tsx
@@ -45,7 +45,7 @@ function LoginForm() {
   const { mutate: loginUserMutation, isLoading: isLoginUserMutationLoading } = useAuthMutation(loginUser, {
     onSuccess: async (res) => {
       if (res?.response && res?.response?.message === 'TWO FACTOR AUTHENTICATION CODE SENT') {
-        localStorage.setItem('zpt', res?.response?.token);
+        localStorage.setItem('2fa', res?.response?.token);
         localStorage.setItem('email', res?.response?.email);
         notify({
           message: 'Two Factor Authentication Code Sent',

--- a/pages/auth/facebook-redirect.tsx
+++ b/pages/auth/facebook-redirect.tsx
@@ -21,7 +21,7 @@ function FacebookRedirect() {
       // Checking if user enabled 2fa
       if (data?.response && data?.response?.message === 'TWO FACTOR AUTHENTICATION CODE SENT') {
         // Setting to localStorage because 2fa page needs them
-        localStorage.setItem('zpt', data?.response?.token);
+        localStorage.setItem('2fa', data?.response?.token);
         localStorage.setItem('email', data?.response?.email);
 
         router.push('/auth/2fa');

--- a/pages/auth/github-redirect.tsx
+++ b/pages/auth/github-redirect.tsx
@@ -21,7 +21,7 @@ function GithubRedirect() {
       // Checking if user enabled 2fa
       if (data?.response && data?.response?.message === 'TWO FACTOR AUTHENTICATION CODE SENT') {
         // Setting to localStorage because 2fa page needs them
-        localStorage.setItem('zpt', data?.response?.token);
+        localStorage.setItem('2fa', data?.response?.token);
         localStorage.setItem('email', data?.response?.email);
 
         router.push('/auth/2fa');

--- a/pages/auth/google-redirect.tsx
+++ b/pages/auth/google-redirect.tsx
@@ -21,7 +21,7 @@ function GoogleRedirect() {
       // Checking if user enabled 2fa
       if (data?.response && data?.response?.message === 'TWO FACTOR AUTHENTICATION CODE SENT') {
         // Setting to localStorage because 2fa page needs them
-        localStorage.setItem('zpt', data?.response?.token);
+        localStorage.setItem('2fa', data?.response?.token);
         localStorage.setItem('email', data?.response?.email);
 
         router.push('/auth/2fa');


### PR DESCRIPTION
# Issue: 

Bug on 2FA that allows users to log in without providing the 6-digits code 

# Changes proposed

> What caused this bug was saving the 2fa token obtained from the backend with the same name the token obtained after logging in is saved by. I just changed the names and made sure that the two localStorage pairs needed to verify 2fa are deleted after login.


# Videos

The bug on staging: https://vimeo.com/876453238
The bug fixed: https://vimeo.com/manage/videos/876455065
